### PR TITLE
Implement base definition reviewer

### DIFF
--- a/src/reviewers/sd/AggregateSDReviewer.ts
+++ b/src/reviewers/sd/AggregateSDReviewer.ts
@@ -1,11 +1,11 @@
 import { StructureDefinition } from 'fhir/r4';
-import { FHIRVersionReviewer } from '.';
+import { FHIRVersionReviewer, BaseDefinitionReviewer } from '.';
 import { AggregateReviewer, Review } from '..';
 import { SDReviewer } from './SDReviewer';
 
 export class AggregateSDReviewer extends AggregateReviewer implements SDReviewer {
   readonly name = 'StructureDefinition Reviewer';
-  reviewers = [new FHIRVersionReviewer()];
+  reviewers = [new FHIRVersionReviewer(), new BaseDefinitionReviewer()];
 
   review(a: StructureDefinition, b: StructureDefinition): Review {
     return super.review(a, b);

--- a/src/reviewers/sd/BaseDefinitionReviewer.ts
+++ b/src/reviewers/sd/BaseDefinitionReviewer.ts
@@ -6,6 +6,23 @@ export class BaseDefinitionReviewer implements SDReviewer {
   readonly name = 'Base Definition Reviewer';
   review(a: StructureDefinition, b: StructureDefinition): Review {
     const review = new Review(this.name, a.id, b.id);
+    if (a.type == null || b.type == null) {
+      const transgressors: string[] = [];
+      if (a.type == null) {
+        transgressors.push('A');
+      }
+      if (b.type == null) {
+        transgressors.push('B');
+      }
+      return review
+        .withResult(ReviewResult.UNKNOWN)
+        .withMessage(
+          `${transgressors.join(' and ')} ${
+            transgressors.length === 1 ? 'does' : 'do'
+          } not declare a type. Type is a required element of StructureDefinition.`
+        );
+    }
+
     if (a.type !== b.type) {
       return review
         .withResult(ReviewResult.DISJOINT)

--- a/src/reviewers/sd/BaseDefinitionReviewer.ts
+++ b/src/reviewers/sd/BaseDefinitionReviewer.ts
@@ -1,0 +1,17 @@
+import { SDReviewer } from './SDReviewer';
+import { StructureDefinition } from 'fhir/r4';
+import { Review, ReviewResult } from '../Review';
+
+export class BaseDefinitionReviewer implements SDReviewer {
+  readonly name = 'Base Definition Reviewer';
+  review(a: StructureDefinition, b: StructureDefinition): Review {
+    const review = new Review(this.name, a.id, b.id);
+    if (a.type !== b.type) {
+      return review
+        .withResult(ReviewResult.DISJOINT)
+        .withMessage(`A and B do not have the same types (A: ${a.type}, B: ${b.type}).`);
+    }
+
+    return review.withResult(ReviewResult.EQUIVALENT);
+  }
+}

--- a/src/reviewers/sd/index.ts
+++ b/src/reviewers/sd/index.ts
@@ -1,2 +1,3 @@
 export * from './AggregateSDReviewer';
+export * from './BaseDefinitionReviewer';
 export * from './FHIRVersionReviewer';

--- a/test/reviewers/sd/AggregateSDReviewer.test.ts
+++ b/test/reviewers/sd/AggregateSDReviewer.test.ts
@@ -23,7 +23,10 @@ describe('AggregateSDReviewer', () => {
   });
 
   it('should be initialized with the correct reviewers', () => {
-    expect(reviewer.reviewers.map(r => r.name)).toEqual(['FHIR Version Reviewer']);
+    expect(reviewer.reviewers.map(r => r.name)).toEqual([
+      'FHIR Version Reviewer',
+      'Base Definition Reviewer'
+    ]);
   });
 
   it('should return an aggregate review first', () => {
@@ -36,7 +39,7 @@ describe('AggregateSDReviewer', () => {
         ReviewResult.EQUIVALENT
       )
     );
-    expect(result.details.childReviews).toHaveLength(1);
+    expect(result.details.childReviews).toHaveLength(2);
   });
 
   it('should return reviews for all registered reviewers', () => {

--- a/test/reviewers/sd/BaseDefinitionReviewer.test.ts
+++ b/test/reviewers/sd/BaseDefinitionReviewer.test.ts
@@ -40,4 +40,44 @@ describe('BaseDefinitionReviewer', () => {
         .withMessage('A and B do not have the same types (A: Patient, B: Observation).')
     );
   });
+
+  it('should assess two profiles as unknown when A is missing type', () => {
+    delete a.type;
+
+    const result = reviewer.review(a, b);
+    expect(result).toEqual(
+      stubReview
+        .withResult(ReviewResult.UNKNOWN)
+        .withMessage(
+          'A does not declare a type. Type is a required element of StructureDefinition.'
+        )
+    );
+  });
+
+  it('should assess two profiles as unknown when B is missing type', () => {
+    delete b.type;
+
+    const result = reviewer.review(a, b);
+    expect(result).toEqual(
+      stubReview
+        .withResult(ReviewResult.UNKNOWN)
+        .withMessage(
+          'B does not declare a type. Type is a required element of StructureDefinition.'
+        )
+    );
+  });
+
+  it('should assess two profiles as unknown when A and B are missing type', () => {
+    delete a.type;
+    delete b.type;
+
+    const result = reviewer.review(a, b);
+    expect(result).toEqual(
+      stubReview
+        .withResult(ReviewResult.UNKNOWN)
+        .withMessage(
+          'A and B do not declare a type. Type is a required element of StructureDefinition.'
+        )
+    );
+  });
 });

--- a/test/reviewers/sd/BaseDefinitionReviewer.test.ts
+++ b/test/reviewers/sd/BaseDefinitionReviewer.test.ts
@@ -1,0 +1,43 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { BaseDefinitionReviewer } from '../../../src/reviewers/sd';
+import { StructureDefinition } from 'fhir/r4';
+import { Review, ReviewResult } from '../../../src/reviewers';
+
+describe('BaseDefinitionReviewer', () => {
+  let reviewer: BaseDefinitionReviewer;
+  let stubReview: Review;
+  let a: StructureDefinition;
+  let b: StructureDefinition;
+
+  beforeEach(() => {
+    reviewer = new BaseDefinitionReviewer();
+    stubReview = new Review('Base Definition Reviewer', 'simple-patient-a', 'simple-patient-b');
+    a = fs.readJSONSync(
+      path.join(__dirname, 'fixtures', 'StructureDefinition-simple-patient-a.json')
+    );
+    b = fs.readJSONSync(
+      path.join(__dirname, 'fixtures', 'StructureDefinition-simple-patient-b.json')
+    );
+  });
+
+  it('should have the correct name', () => {
+    expect(reviewer.name).toBe('Base Definition Reviewer');
+  });
+
+  it('should assess two profiles with the same type as equivalent', () => {
+    const result = reviewer.review(a, b);
+    expect(result).toEqual(stubReview.withResult(ReviewResult.EQUIVALENT));
+  });
+
+  it('should assess two profiles with different types as disjoint', () => {
+    b.type = 'Observation';
+
+    const result = reviewer.review(a, b);
+    expect(result).toEqual(
+      stubReview
+        .withResult(ReviewResult.DISJOINT)
+        .withMessage('A and B do not have the same types (A: Patient, B: Observation).')
+    );
+  });
+});


### PR DESCRIPTION
Completes task [CIMPL-854](https://standardhealthrecord.atlassian.net/browse/CIMPL-854).

This reviewer's job is to make sure that the two StructureDefinitions are the same type. This mostly works like checking the FHIR version, with the main difference being that type is a required element on StructureDefinition. So, the message when a type is missing reminds the user that the current situation is no good.