### PR TITLE
Package loader and fisher

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,9 @@ import process from 'process';
 import fs from 'fs-extra';
 import chalk, { Chalk } from 'chalk';
 import { padStart, padEnd } from 'lodash';
-import { logger } from './utils';
+import { loadDependency } from 'fhir-package-loader';
+import { determineCorePackageId, loadExternalDependencies } from './utils/Dependencies';
+import { logger, logMessage } from './utils';
 import { StructureDefinition } from 'fhir/r4';
 import { AggregateSDReviewer } from './reviewers/sd';
 import { Review, ReviewResult } from './reviewers';
@@ -29,11 +31,10 @@ async function app() {
       '-b, --resourceB <filepath>',
       'the file path to the second resource for comparison'
     )
-    // TODO: Implement dependency loading
-    // .option(
-    //   '-d, --dependency <dependency...>',
-    //   'specify dependencies to be loaded using format dependencyId@version (FHIR R4 included by default)'
-    // )
+    .option(
+      '-d, --dependency <dependency...>',
+      'specify dependencies to be loaded using format dependencyId@version (FHIR R4 included by default)'
+    )
     .option(
       '-l, --log-level <level>',
       'specify the level of log messages: error, warn, info (default), debug'
@@ -47,7 +48,7 @@ async function app() {
     .opts();
 
   // Set the log level. If no level specified, loggers default to info
-  const { logLevel } = options;
+  const { logLevel, dependency = [] } = options;
   if (logLevel === 'debug' || logLevel === 'warn' || logLevel === 'error') {
     logger.level = logLevel;
   }
@@ -56,12 +57,13 @@ async function app() {
   logger.info('Arguments:');
   logger.info(`  --resourceA ${options.resourceA}`);
   logger.info(`  --resourceB ${options.resourceB}`);
-  // TODO: Implement dependency loading
-  // if (options.dependency) {
-  //   options.dependency.forEach((d: string) =>
-  //     logger.info(`  --dependency ${d}`)
-  //   );
-  // }
+  if (dependency) {
+    dependency.forEach((d: string) => logger.info(`  --dependency ${d}`));
+  }
+
+  // Load FHIR R4 and included dependencies
+  const defs = await loadExternalDependencies(dependency);
+
   if (options.logLevel) {
     logger.info(`  --log-level ${options.logLevel}`);
   }
@@ -77,6 +79,16 @@ async function app() {
   }
 
   if (a && b) {
+    // Load FHIR core versions to FHIR Defs
+    if (a.fhirVersion && a.fhirVersion !== '4.0.1') {
+      const fhirPackageId = determineCorePackageId(a.fhirVersion);
+      loadDependency(fhirPackageId, a.fhirVersion, defs, undefined, logMessage);
+    }
+    if (b.fhirVersion && b.fhirVersion !== '4.0.1') {
+      const fhirPackageId = determineCorePackageId(b.fhirVersion);
+      loadDependency(fhirPackageId, b.fhirVersion, defs, undefined, logMessage);
+    }
+
     const reviewer = new AggregateSDReviewer();
     const review = reviewer.review(a, b);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -82,11 +82,15 @@ async function app() {
     // Load FHIR core versions to FHIR Defs
     if (a.fhirVersion && a.fhirVersion !== '4.0.1') {
       const fhirPackageId = determineCorePackageId(a.fhirVersion);
-      loadDependency(fhirPackageId, a.fhirVersion, defs, undefined, logMessage);
+      if (!defs.childFHIRDefs.filter(def => def.package === `${fhirPackageId}#${a.fhirVersion}`)) {
+        loadDependency(fhirPackageId, a.fhirVersion, defs, undefined, logMessage);
+      }
     }
     if (b.fhirVersion && b.fhirVersion !== '4.0.1') {
       const fhirPackageId = determineCorePackageId(b.fhirVersion);
-      loadDependency(fhirPackageId, b.fhirVersion, defs, undefined, logMessage);
+      if (!defs.childFHIRDefs.filter(def => def.package === `${fhirPackageId}#${b.fhirVersion}`)) {
+        loadDependency(fhirPackageId, b.fhirVersion, defs, undefined, logMessage);
+      }
     }
 
     const reviewer = new AggregateSDReviewer();

--- a/src/app.ts
+++ b/src/app.ts
@@ -82,13 +82,17 @@ async function app() {
     // Load FHIR core versions to FHIR Defs
     if (a.fhirVersion && a.fhirVersion !== '4.0.1') {
       const fhirPackageId = determineCorePackageId(a.fhirVersion);
-      if (!defs.childFHIRDefs.filter(def => def.package === `${fhirPackageId}#${a.fhirVersion}`)) {
+      if (
+        !defs.allPackages().find(packageId => packageId === `${fhirPackageId}#${a.fhirVersion}`)
+      ) {
         loadDependency(fhirPackageId, a.fhirVersion, defs, undefined, logMessage);
       }
     }
     if (b.fhirVersion && b.fhirVersion !== '4.0.1') {
       const fhirPackageId = determineCorePackageId(b.fhirVersion);
-      if (!defs.childFHIRDefs.filter(def => def.package === `${fhirPackageId}#${b.fhirVersion}`)) {
+      if (
+        !defs.allPackages().find(packageId => packageId === `${fhirPackageId}#${b.fhirVersion}`)
+      ) {
         loadDependency(fhirPackageId, b.fhirVersion, defs, undefined, logMessage);
       }
     }

--- a/src/utils/Dependencies.ts
+++ b/src/utils/Dependencies.ts
@@ -2,24 +2,26 @@ import { loadDependencies, FHIRDefinitions } from 'fhir-package-loader';
 import { logger, logMessage } from './Logger';
 
 export function reformatDependencies(dependencies: string[]): string[] {
-  const parsedDepencies = dependencies.reduce(function (workingArray, dep) {
+  const parsedDependencies = dependencies.reduce(function (workingArray, dep) {
     const versionSplit = dep.split('@');
     if (versionSplit.length !== 2) {
       logger.error(
-        `Dependency \'${dep}\' is not formatted correctly and will not be loaded. Please specify depdencies using the format dependencyId@version`
+        `Dependency \'${dep}\' is not formatted correctly and will not be loaded. Please specify dependencies using the format dependencyId@version`
       );
     } else {
       workingArray.push(`${versionSplit[0].trim()}#${versionSplit[1].trim()}`);
     }
     return workingArray;
   }, []);
-  return parsedDepencies;
+  return parsedDependencies;
 }
 
 export async function loadExternalDependencies(dependencies: string[]): Promise<FHIRDefinitions> {
   if (dependencies) {
-    const parsedDependencies = ['hl7.fhir.r4.core#4.0.1'];
-    parsedDependencies.push(...reformatDependencies(dependencies));
+    const parsedDependencies = reformatDependencies(dependencies);
+    if (!parsedDependencies.includes('hl7.fhir.r4.core#4.0.1')) {
+      parsedDependencies.push('hl7.fhir.r4.core#4.0.1');
+    }
     return loadDependencies(parsedDependencies, undefined, logMessage);
   }
 }

--- a/src/utils/Dependencies.ts
+++ b/src/utils/Dependencies.ts
@@ -1,0 +1,39 @@
+import { loadDependencies, FHIRDefinitions } from 'fhir-package-loader';
+import { logger, logMessage } from './Logger';
+
+export function reformatDependencies(dependencies: string[]): string[] {
+  const parsedDepencies = dependencies.reduce(function (workingArray, dep) {
+    const versionSplit = dep.split('@');
+    if (versionSplit.length !== 2) {
+      logger.error(
+        `Dependency \'${dep}\' is not formatted correctly and will not be loaded. Please specify depdencies using the format dependencyId@version`
+      );
+    } else {
+      workingArray.push(`${versionSplit[0].trim()}#${versionSplit[1].trim()}`);
+    }
+    return workingArray;
+  }, []);
+  return parsedDepencies;
+}
+
+export async function loadExternalDependencies(dependencies: string[]): Promise<FHIRDefinitions> {
+  if (dependencies) {
+    const parsedDependencies = ['hl7.fhir.r4.core#4.0.1'];
+    parsedDependencies.push(...reformatDependencies(dependencies));
+    return loadDependencies(parsedDependencies, undefined, logMessage);
+  }
+}
+
+export function determineCorePackageId(fhirVersion: string): string {
+  if (/^4\.0\./.test(fhirVersion)) {
+    return 'hl7.fhir.r4.core';
+  } else if (/^(4\.1\.|4\.3.\d+-)/.test(fhirVersion)) {
+    return 'hl7.fhir.r4b.core';
+  } else if (/^4\.3.\d+$/.test(fhirVersion)) {
+    return 'hl7.fhir.r4b.core';
+  } else if (/^5\.0.\d+$/.test(fhirVersion)) {
+    return 'hl7.fhir.r5.core';
+  } else {
+    return 'hl7.fhir.r5.core';
+  }
+}

--- a/src/utils/Fisher.ts
+++ b/src/utils/Fisher.ts
@@ -1,0 +1,113 @@
+import { FHIRDefinitions, Type, Metadata } from 'fhir-package-loader';
+import { cloneDeep } from 'lodash';
+
+export class Fisher {
+  protected fhirDefs: FHIRDefinitions;
+
+  constructor(defs: FHIRDefinitions) {
+    this.fhirDefs = defs;
+  }
+
+  /**
+   * Search for a definition based on the type it could be
+   * @param {string} item - the item to search for
+   * @param {Type[]} types - the possible type the item could be
+   * @returns the definition that is returned or undefined if none is found
+   */
+  fishForFHIR(item: string, ...types: Type[]): any | undefined {
+    // No types passed in means to search ALL supported types
+    if (types.length === 0) {
+      types = [
+        Type.Resource,
+        Type.Logical,
+        Type.Type,
+        Type.Profile,
+        Type.Extension,
+        Type.ValueSet,
+        Type.CodeSystem
+      ];
+    }
+
+    for (const type of types) {
+      let def;
+      switch (type) {
+        case Type.Resource:
+          def = cloneDeep(
+            this.fhirDefs
+              .allResources()
+              .find(def => def.id === item || def.url === item || def.name === item)
+          );
+          break;
+        case Type.Logical:
+          def = cloneDeep(
+            this.fhirDefs
+              .allLogicals()
+              .find(def => def.id === item || def.url === item || def.name === item)
+          );
+          break;
+        case Type.Type:
+          def = cloneDeep(
+            this.fhirDefs
+              .allTypes()
+              .find(def => def.id === item || def.url === item || def.name === item)
+          );
+          break;
+        case Type.Profile:
+          def = cloneDeep(
+            this.fhirDefs
+              .allProfiles()
+              .find(def => def.id === item || def.url === item || def.name === item)
+          );
+          break;
+        case Type.Extension:
+          def = cloneDeep(
+            this.fhirDefs
+              .allExtensions()
+              .find(def => def.id === item || def.url === item || def.name === item)
+          );
+          break;
+        case Type.ValueSet:
+          def = cloneDeep(
+            this.fhirDefs
+              .allValueSets()
+              .find(def => def.id === item || def.url === item || def.name === item)
+          );
+          break;
+        case Type.CodeSystem:
+          def = cloneDeep(
+            this.fhirDefs
+              .allCodeSystems()
+              .find(def => def.id === item || def.url === item || def.name === item)
+          );
+          break;
+        case Type.Instance: // don't support resolving to FHIR instances
+        default:
+          break;
+      }
+      if (def) {
+        return def;
+      }
+    }
+  }
+
+  /**
+   * Search for the metadata of a definition based on the type it could be
+   * @param {string} item - the item to search for
+   * @param {Type[]} types - the possible types the item could be
+   * @returns {Metadata | undefined} the metadata of the item or undefined if none is found
+   */
+  fishForMetadata(item: string, ...types: Type[]): Metadata | undefined {
+    const result = this.fishForFHIR(item, ...types);
+    if (result) {
+      return {
+        id: result.id as string,
+        name: result.name as string,
+        sdType: result.type as string,
+        url: result.url as string,
+        parent: result.baseDefinition as string,
+        abstract: result.abstract as boolean,
+        resourceType: result.resourceType as string
+      };
+    }
+  }
+}

--- a/src/utils/Fisher.ts
+++ b/src/utils/Fisher.ts
@@ -1,5 +1,15 @@
-import { FHIRDefinitions, Type, Metadata } from 'fhir-package-loader';
+import { FHIRDefinitions, Type } from 'fhir-package-loader';
 import { cloneDeep } from 'lodash';
+
+interface Metadata {
+  id: string;
+  name: string;
+  sdType?: string;
+  resourceType?: string;
+  url?: string;
+  parent?: string;
+  abstract?: boolean;
+}
 
 export class Fisher {
   protected fhirDefs: FHIRDefinitions;

--- a/src/utils/Fisher.ts
+++ b/src/utils/Fisher.ts
@@ -1,5 +1,4 @@
 import { FHIRDefinitions, Type } from 'fhir-package-loader';
-import { cloneDeep } from 'lodash';
 
 interface Metadata {
   id: string;
@@ -42,53 +41,25 @@ export class Fisher {
       let def;
       switch (type) {
         case Type.Resource:
-          def = cloneDeep(
-            this.fhirDefs
-              .allResources()
-              .find(def => def.id === item || def.url === item || def.name === item)
-          );
+          def = this.fhirDefs.fishForFHIR(item, Type.Resource);
           break;
         case Type.Logical:
-          def = cloneDeep(
-            this.fhirDefs
-              .allLogicals()
-              .find(def => def.id === item || def.url === item || def.name === item)
-          );
+          def = this.fhirDefs.fishForFHIR(item, Type.Logical);
           break;
         case Type.Type:
-          def = cloneDeep(
-            this.fhirDefs
-              .allTypes()
-              .find(def => def.id === item || def.url === item || def.name === item)
-          );
+          def = this.fhirDefs.fishForFHIR(item, Type.Type);
           break;
         case Type.Profile:
-          def = cloneDeep(
-            this.fhirDefs
-              .allProfiles()
-              .find(def => def.id === item || def.url === item || def.name === item)
-          );
+          def = this.fhirDefs.fishForFHIR(item, Type.Profile);
           break;
         case Type.Extension:
-          def = cloneDeep(
-            this.fhirDefs
-              .allExtensions()
-              .find(def => def.id === item || def.url === item || def.name === item)
-          );
+          def = this.fhirDefs.fishForFHIR(item, Type.Extension);
           break;
         case Type.ValueSet:
-          def = cloneDeep(
-            this.fhirDefs
-              .allValueSets()
-              .find(def => def.id === item || def.url === item || def.name === item)
-          );
+          def = this.fhirDefs.fishForFHIR(item, Type.ValueSet);
           break;
         case Type.CodeSystem:
-          def = cloneDeep(
-            this.fhirDefs
-              .allCodeSystems()
-              .find(def => def.id === item || def.url === item || def.name === item)
-          );
+          def = this.fhirDefs.fishForFHIR(item, Type.CodeSystem);
           break;
         case Type.Instance: // don't support resolving to FHIR instances
         default:

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -70,6 +70,10 @@ export const logger = createLogger({
   transports: [new transports.Console()]
 });
 
+export const logMessage = (level: string, message: string): void => {
+  logger.log(level, message);
+};
+
 class LoggerStats {
   public numInfo = 0;
   public numWarn = 0;

--- a/test/utils/Dependencies.test.ts
+++ b/test/utils/Dependencies.test.ts
@@ -10,7 +10,6 @@ describe('Dependencies', () => {
     loggerSpy.reset();
   });
 
-  // TODO: Add a describe bloc for determineCorePackageId
   describe('determineCorePackageId', () => {
     it('should recognize FHIR R4 version numbers', () => {
       const packageId1 = determineCorePackageId('4.0.1');

--- a/test/utils/Dependencies.test.ts
+++ b/test/utils/Dependencies.test.ts
@@ -1,0 +1,74 @@
+import {
+  reformatDependencies,
+  loadExternalDependencies,
+  determineCorePackageId
+} from '../../src/utils/Dependencies';
+import { loggerSpy } from '../testhelpers/loggerSpy';
+
+describe('Dependencies', () => {
+  beforeEach(() => {
+    loggerSpy.reset();
+  });
+
+  describe('determineCorePackageId', () => {
+    it('should recognize FHIR R4 version numbers', () => {
+      const packageId1 = determineCorePackageId('4.0.1');
+      const packageId2 = determineCorePackageId('4.0.0');
+      expect(packageId1).toBe('hl7.fhir.r4.core');
+      expect(packageId2).toBe('hl7.fhir.r4.core');
+    });
+
+    it('should recognize FHIR R4B version numbers', () => {
+      const packageId1 = determineCorePackageId('4.1.0');
+      const packageId2 = determineCorePackageId('4.3.0');
+      expect(packageId1).toBe('hl7.fhir.r4b.core');
+      expect(packageId2).toBe('hl7.fhir.r4b.core');
+    });
+
+    it('should recognize FHIR R5 version numbers', () => {
+      const packageId1 = determineCorePackageId('5.0.0');
+      const packageId2 = determineCorePackageId('5.5.0');
+      expect(packageId1).toBe('hl7.fhir.r5.core');
+      expect(packageId2).toBe('hl7.fhir.r5.core');
+    });
+  });
+
+  describe('loadExternalDependencies', () => {
+    it('should load specified dependencies', async () => {
+      const dependencies = ['hl7.fhir.us.core@3.1.0', 'hl7.fhir.us.mcode@1.0.0'];
+      const defs = await loadExternalDependencies(dependencies);
+      expect(defs.childFHIRDefs).toHaveLength(3);
+      expect(defs.childFHIRDefs[0].package).toBe('hl7.fhir.r4.core#4.0.1');
+      expect(defs.childFHIRDefs[1].package).toBe('hl7.fhir.us.core#3.1.0');
+      expect(defs.childFHIRDefs[2].package).toBe('hl7.fhir.us.mcode#1.0.0');
+    });
+  });
+
+  describe('reformatDependencies', () => {
+    it('should split an array of dependencies on @', () => {
+      const dependencies = ['hl7.fhir.us.core@3.1.1', 'hl7.fhir.us.mcode@1.2.0'];
+      const parsedDependencies = reformatDependencies(dependencies);
+      expect(parsedDependencies).toHaveLength(2);
+      expect(parsedDependencies).toContain('hl7.fhir.us.core#3.1.1');
+      expect(parsedDependencies).toContain('hl7.fhir.us.mcode#1.2.0');
+    });
+    it('should trim empty space from packageIds and version numbers', () => {
+      const dependencies = [' hl7.fhir.us.core@3.1.1', 'hl7.fhir.us.mcode@1.2.0 '];
+      const parsedDependencies = reformatDependencies(dependencies);
+      expect(parsedDependencies).toHaveLength(2);
+      expect(parsedDependencies).toContain('hl7.fhir.us.core#3.1.1');
+      expect(parsedDependencies).toContain('hl7.fhir.us.mcode#1.2.0');
+    });
+
+    it('should log an error when @ is not used to seperate version numbers from packageIds', () => {
+      const dependencies = [' hl7.fhir.us.core#3.1.1', 'hl7.fhir.us.mcode@1.2.0 '];
+      const parsedDependencies = reformatDependencies(dependencies);
+      expect(loggerSpy.getLastMessage('error')).toBe(
+        "Dependency ' hl7.fhir.us.core#3.1.1' is not formatted correctly and will not be loaded. Please specify depdencies using the format dependencyId@version"
+      );
+      expect(parsedDependencies).toHaveLength(1);
+      expect(parsedDependencies).not.toContain('hl7.fhir.us.core#3.1.1');
+      expect(parsedDependencies).toContain('hl7.fhir.us.mcode#1.2.0');
+    });
+  });
+});

--- a/test/utils/Dependencies.test.ts
+++ b/test/utils/Dependencies.test.ts
@@ -10,6 +10,7 @@ describe('Dependencies', () => {
     loggerSpy.reset();
   });
 
+  // TODO: Add a describe bloc for determineCorePackageId
   describe('determineCorePackageId', () => {
     it('should recognize FHIR R4 version numbers', () => {
       const packageId1 = determineCorePackageId('4.0.1');
@@ -38,9 +39,9 @@ describe('Dependencies', () => {
       const dependencies = ['hl7.fhir.us.core@3.1.0', 'hl7.fhir.us.mcode@1.0.0'];
       const defs = await loadExternalDependencies(dependencies);
       expect(defs.childFHIRDefs).toHaveLength(3);
-      expect(defs.childFHIRDefs[0].package).toBe('hl7.fhir.r4.core#4.0.1');
-      expect(defs.childFHIRDefs[1].package).toBe('hl7.fhir.us.core#3.1.0');
-      expect(defs.childFHIRDefs[2].package).toBe('hl7.fhir.us.mcode#1.0.0');
+      expect(defs.childFHIRDefs[0].package).toBe('hl7.fhir.us.core#3.1.0');
+      expect(defs.childFHIRDefs[1].package).toBe('hl7.fhir.us.mcode#1.0.0');
+      expect(defs.childFHIRDefs[2].package).toBe('hl7.fhir.r4.core#4.0.1');
     });
   });
 
@@ -64,7 +65,7 @@ describe('Dependencies', () => {
       const dependencies = [' hl7.fhir.us.core#3.1.1', 'hl7.fhir.us.mcode@1.2.0 '];
       const parsedDependencies = reformatDependencies(dependencies);
       expect(loggerSpy.getLastMessage('error')).toBe(
-        "Dependency ' hl7.fhir.us.core#3.1.1' is not formatted correctly and will not be loaded. Please specify depdencies using the format dependencyId@version"
+        "Dependency ' hl7.fhir.us.core#3.1.1' is not formatted correctly and will not be loaded. Please specify dependencies using the format dependencyId@version"
       );
       expect(parsedDependencies).toHaveLength(1);
       expect(parsedDependencies).not.toContain('hl7.fhir.us.core#3.1.1');

--- a/test/utils/Fisher.test.ts
+++ b/test/utils/Fisher.test.ts
@@ -1,0 +1,83 @@
+import { Fisher } from '../../src/utils/Fisher';
+import { loadExternalDependencies } from '../../src/utils/Dependencies';
+import { FHIRDefinitions, Type } from 'fhir-package-loader';
+
+let defs: FHIRDefinitions;
+let fisher: Fisher;
+
+describe('Fisher', () => {
+  beforeAll(async () => {
+    defs = await loadExternalDependencies(['hl7.fhir.us.mcode@1.0.0']);
+    fisher = new Fisher(defs);
+  });
+
+  describe('fishForFHIR', () => {
+    it('should fish based on resource name', () => {
+      const cancerPatient = fisher.fishForFHIR('CancerPatient', Type.Profile);
+      expect(cancerPatient).toBeDefined();
+      expect(cancerPatient.resourceType).toBe('StructureDefinition');
+    });
+
+    it('should fish based on resource id', () => {
+      const cancerPatient = fisher.fishForFHIR('mcode-cancer-patient', Type.Profile);
+      expect(cancerPatient).toBeDefined();
+      expect(cancerPatient.resourceType).toBe('StructureDefinition');
+    });
+
+    it('should fish based on resource url', () => {
+      const cancerPatient = fisher.fishForFHIR(
+        'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient',
+        Type.Profile
+      );
+      expect(cancerPatient).toBeDefined();
+      expect(cancerPatient.resourceType).toBe('StructureDefinition');
+    });
+  });
+
+  describe('fishForMetadata', () => {
+    it('should fish metadata based on resource name', () => {
+      const cancerPatientMetadata = fisher.fishForMetadata('CancerPatient', Type.Profile);
+      expect(cancerPatientMetadata).toBeDefined();
+      expect(cancerPatientMetadata).toEqual({
+        id: 'mcode-cancer-patient',
+        name: 'CancerPatient',
+        sdType: 'Patient',
+        url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient',
+        parent: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
+        abstract: false,
+        resourceType: 'StructureDefinition'
+      });
+    });
+
+    it('should fish metadata based on resource id', () => {
+      const cancerPatientMetadata = fisher.fishForMetadata('mcode-cancer-patient', Type.Profile);
+      expect(cancerPatientMetadata).toBeDefined();
+      expect(cancerPatientMetadata).toEqual({
+        id: 'mcode-cancer-patient',
+        name: 'CancerPatient',
+        sdType: 'Patient',
+        url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient',
+        parent: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
+        abstract: false,
+        resourceType: 'StructureDefinition'
+      });
+    });
+
+    it('should fish metadata based on resource url', () => {
+      const cancerPatientMetadata = fisher.fishForMetadata(
+        'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient',
+        Type.Profile
+      );
+      expect(cancerPatientMetadata).toBeDefined();
+      expect(cancerPatientMetadata).toEqual({
+        id: 'mcode-cancer-patient',
+        name: 'CancerPatient',
+        sdType: 'Patient',
+        url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient',
+        parent: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
+        abstract: false,
+        resourceType: 'StructureDefinition'
+      });
+    });
+  });
+});

--- a/test/utils/Fisher.test.ts
+++ b/test/utils/Fisher.test.ts
@@ -1,5 +1,6 @@
 import { Fisher } from '../../src/utils/Fisher';
 import { loadExternalDependencies } from '../../src/utils/Dependencies';
+import { loggerSpy } from '../testhelpers/loggerSpy';
 import { FHIRDefinitions, Type } from 'fhir-package-loader';
 
 let defs: FHIRDefinitions;
@@ -9,9 +10,12 @@ describe('Fisher', () => {
   beforeAll(async () => {
     defs = await loadExternalDependencies(['hl7.fhir.us.mcode@1.0.0']);
     fisher = new Fisher(defs);
+    loggerSpy.reset();
   });
 
   describe('fishForFHIR', () => {
+    // TODO: Add unit tests to ensure all supported Types can be fished
+    // TODO: Add unit test to ensure all Types are fished for when no Type is included
     it('should fish based on resource name', () => {
       const cancerPatient = fisher.fishForFHIR('CancerPatient', Type.Profile);
       expect(cancerPatient).toBeDefined();
@@ -35,6 +39,7 @@ describe('Fisher', () => {
   });
 
   describe('fishForMetadata', () => {
+    // TODO: Add unit tests to ensure metadata for all supported Types can be fished
     it('should fish metadata based on resource name', () => {
       const cancerPatientMetadata = fisher.fishForMetadata('CancerPatient', Type.Profile);
       expect(cancerPatientMetadata).toBeDefined();


### PR DESCRIPTION
Implements dependency loading and fishing within FM. The fisher works similarly to the `MasterFisher` in SUSHI and GoFSH, but it really only fishes within `FHIRDefinitions` so I thought it wasn't worthy of being a master. 

These changes rely upon the new [FHIR Package Loader](https://github.com/standardhealth/fhir-package-loader) tool. I chose to integrate the new module into this project by running `npm pack` from the base of the `fhir-package-loader` repo, copying the generated `.tgz` file into the FM project, and then running `npm install <generated-tgz-name>.tgz>`